### PR TITLE
Update mergesort.py

### DIFF
--- a/mergesort.py
+++ b/mergesort.py
@@ -41,7 +41,7 @@ def split_merge(ds, head, tail, frames):
         # FRAME OPERATION BEGIN
         frames.append(copy.deepcopy(ds_yb))
         # FRAME OPERATION END
-        if right == tail or (left < mid and ds[left].value <= ds[right].value):
+        if (right == tail or (left < mid and ds[left].value <= ds[right].value)) and ds[left] not in tmp_list:
             tmp_list.append(ds[left])
             # FRAME OPERATION BEGIN
             frames[-1][left].set_color('r')


### PR DESCRIPTION
原作者归并排序的判断处有bug，如以下情况
[2, 7, 5, 8, 10, 4, 6, 9, 1, 3]  取head = 2, tail = 5, mid = 3
在40行处的for循环会进行三次
第一次，执行if语句 tmp_list = [5]
第二次，执行else语句 tmp_list = [5,8]
第三次，执行if语句 tmp_list = [5,8,8]           <-  bug在这里出现
8（ds[3]）这个值 在第二次for循环已经进入了tmp_list， 但是原判断条件 left<mid, ds[left].value<=ds[right].value 均为真。所以重复将这个值放入tmp_list，却丢弃了10（ds[4]）